### PR TITLE
Change from 'torii' to '@adopted-ember-addons/torii'

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ session and torii services like so:
 
 ```
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'torii/routing/authenticated-route-mixin';
+import AuthenticatedRouteMixin from '@adopted-ember-addons/torii/routing/authenticated-route-mixin';
 import { inject as service } from '@ember/service';
 
 export default class MyAuthenticatedRoute extends Route.extend(AuthenticatedRouteMixin) {

--- a/addon/bootstrap/routing.js
+++ b/addon/bootstrap/routing.js
@@ -1,6 +1,6 @@
-import ApplicationRouteMixin from 'torii/routing/application-route-mixin';
-import AuthenticatedRouteMixin from 'torii/routing/authenticated-route-mixin';
-import { lookup, lookupFactory, register } from 'torii/lib/container-utils';
+import ApplicationRouteMixin from '@adopted-ember-addons/torii/routing/application-route-mixin';
+import AuthenticatedRouteMixin from '@adopted-ember-addons/torii/routing/authenticated-route-mixin';
+import { lookup, lookupFactory, register } from '@adopted-ember-addons/torii/lib/container-utils';
 
 var AuthenticatedRoute = null;
 

--- a/addon/bootstrap/session.js
+++ b/addon/bootstrap/session.js
@@ -1,4 +1,4 @@
-import ToriiSessionService from 'torii/services/torii-session';
+import ToriiSessionService from '@adopted-ember-addons/torii/services/torii-session';
 
 export default function (application, sessionName) {
   var sessionFactoryName = 'service:' + sessionName;

--- a/addon/bootstrap/torii.js
+++ b/addon/bootstrap/torii.js
@@ -1,18 +1,18 @@
-import LinkedInOauth2Provider from 'torii/providers/linked-in-oauth2';
-import GoogleOauth2Provider from 'torii/providers/google-oauth2';
-import GoogleOauth2BearerProvider from 'torii/providers/google-oauth2-bearer';
-import GoogleOauth2BearerV2Provider from 'torii/providers/google-oauth2-bearer-v2';
-import FacebookConnectProvider from 'torii/providers/facebook-connect';
-import FacebookOauth2Provider from 'torii/providers/facebook-oauth2';
-import ApplicationAdapter from 'torii/adapters/application';
-import TwitterProvider from 'torii/providers/twitter-oauth1';
-import GithubOauth2Provider from 'torii/providers/github-oauth2';
-import AzureAdOauth2Provider from 'torii/providers/azure-ad-oauth2';
-import StripeConnectProvider from 'torii/providers/stripe-connect';
+import LinkedInOauth2Provider from '@adopted-ember-addons/torii/providers/linked-in-oauth2';
+import GoogleOauth2Provider from '@adopted-ember-addons/torii/providers/google-oauth2';
+import GoogleOauth2BearerProvider from '@adopted-ember-addons/torii/providers/google-oauth2-bearer';
+import GoogleOauth2BearerV2Provider from '@adopted-ember-addons/torii/providers/google-oauth2-bearer-v2';
+import FacebookConnectProvider from '@adopted-ember-addons/torii/providers/facebook-connect';
+import FacebookOauth2Provider from '@adopted-ember-addons/torii/providers/facebook-oauth2';
+import ApplicationAdapter from '@adopted-ember-addons/torii/adapters/application';
+import TwitterProvider from '@adopted-ember-addons/torii/providers/twitter-oauth1';
+import GithubOauth2Provider from '@adopted-ember-addons/torii/providers/github-oauth2';
+import AzureAdOauth2Provider from '@adopted-ember-addons/torii/providers/azure-ad-oauth2';
+import StripeConnectProvider from '@adopted-ember-addons/torii/providers/stripe-connect';
 
-import ToriiService from 'torii/services/torii';
-import PopupService from 'torii/services/popup';
-import IframeService from 'torii/services/iframe';
+import ToriiService from '@adopted-ember-addons/torii/services/torii';
+import PopupService from '@adopted-ember-addons/torii/services/popup';
+import IframeService from '@adopted-ember-addons/torii/services/iframe';
 
 export default function (application) {
   application.register('service:torii', ToriiService);

--- a/addon/mixins/ui-service-mixin.js
+++ b/addon/mixins/ui-service-mixin.js
@@ -3,13 +3,13 @@ import { later, run, cancel } from '@ember/runloop';
 import { Promise as EmberPromise } from 'rsvp';
 import Mixin from '@ember/object/mixin';
 import { on } from '@ember/object/evented';
-import UUIDGenerator from 'torii/lib/uuid-generator';
-import PopupIdSerializer from 'torii/lib/popup-id-serializer';
-import ParseQueryString from 'torii/lib/parse-query-string';
-import assert from 'torii/lib/assert';
+import UUIDGenerator from '@adopted-ember-addons/torii/lib/uuid-generator';
+import PopupIdSerializer from '@adopted-ember-addons/torii/lib/popup-id-serializer';
+import ParseQueryString from '@adopted-ember-addons/torii/lib/parse-query-string';
+import assert from '@adopted-ember-addons/torii/lib/assert';
 export const CURRENT_REQUEST_KEY = '__torii_request';
 export const WARNING_KEY = '__torii_redirect_warning';
-import { getConfiguration } from 'torii/configuration';
+import { getConfiguration } from '@adopted-ember-addons/torii/configuration';
 
 function parseMessage(url, keys) {
   var parser = ParseQueryString.create({ url: url, keys: keys });

--- a/addon/providers/azure-ad-oauth2.js
+++ b/addon/providers/azure-ad-oauth2.js
@@ -1,7 +1,7 @@
 /* eslint-disable ember/require-computed-property-dependencies, ember/no-get, ember/avoid-leaking-state-in-ember-objects */
 import { computed } from '@ember/object';
-import Oauth2 from 'torii/providers/oauth2-code';
-import { configurable } from 'torii/configuration';
+import Oauth2 from '@adopted-ember-addons/torii/providers/oauth2-code';
+import { configurable } from '@adopted-ember-addons/torii/configuration';
 
 /**
  * This class implements authentication against AzureAD

--- a/addon/providers/base.js
+++ b/addon/providers/base.js
@@ -1,9 +1,9 @@
 /* eslint-disable ember/no-classic-classes, ember/no-get */
 import EmberObject, { computed } from '@ember/object';
-import requiredProperty from 'torii/lib/required-property';
-import { getOwner } from 'torii/lib/container-utils';
-import { configurable } from 'torii/configuration';
-import configuration from 'torii/configuration';
+import requiredProperty from '@adopted-ember-addons/torii/lib/required-property';
+import { getOwner } from '@adopted-ember-addons/torii/lib/container-utils';
+import { configurable } from '@adopted-ember-addons/torii/configuration';
+import configuration from '@adopted-ember-addons/torii/configuration';
 
 var DEFAULT_REMOTE_SERVICE_NAME = 'popup';
 

--- a/addon/providers/facebook-connect.js
+++ b/addon/providers/facebook-connect.js
@@ -10,9 +10,9 @@
 
 import { run } from '@ember/runloop';
 import { Promise as EmberPromise } from 'rsvp';
-import Provider from 'torii/providers/base';
+import Provider from '@adopted-ember-addons/torii/providers/base';
 import { loadScript } from './-private/utils';
-import { configurable } from 'torii/configuration';
+import { configurable } from '@adopted-ember-addons/torii/configuration';
 
 var fbPromise;
 

--- a/addon/providers/facebook-oauth2.js
+++ b/addon/providers/facebook-oauth2.js
@@ -1,6 +1,6 @@
 /* eslint-disable ember/no-get, ember/avoid-leaking-state-in-ember-objects */
-import { configurable } from 'torii/configuration';
-import Oauth2 from 'torii/providers/oauth2-code';
+import { configurable } from '@adopted-ember-addons/torii/configuration';
+import Oauth2 from '@adopted-ember-addons/torii/providers/oauth2-code';
 import { computed } from '@ember/object';
 
 export default Oauth2.extend({

--- a/addon/providers/github-oauth2.js
+++ b/addon/providers/github-oauth2.js
@@ -1,6 +1,6 @@
 /* eslint-disable ember/avoid-leaking-state-in-ember-objects */
-import Oauth2 from 'torii/providers/oauth2-code';
-import { configurable } from 'torii/configuration';
+import Oauth2 from '@adopted-ember-addons/torii/providers/oauth2-code';
+import { configurable } from '@adopted-ember-addons/torii/configuration';
 
 /**
  * This class implements authentication against Github

--- a/addon/providers/google-oauth2-bearer-v2.js
+++ b/addon/providers/google-oauth2-bearer-v2.js
@@ -2,8 +2,8 @@
 import { Promise as EmberPromise } from 'rsvp';
 import { run } from '@ember/runloop';
 import { assign } from '@ember/polyfills';
-import OAuth2Code from 'torii/providers/oauth2-code';
-import { configurable } from 'torii/configuration';
+import OAuth2Code from '@adopted-ember-addons/torii/providers/oauth2-code';
+import { configurable } from '@adopted-ember-addons/torii/configuration';
 
 /**
  * This class implements a provider allowing authentication against google's

--- a/addon/providers/google-oauth2-bearer.js
+++ b/addon/providers/google-oauth2-bearer.js
@@ -4,8 +4,8 @@
  * using the client-side OAuth2 authorization flow in a popup window.
  */
 
-import Oauth2Bearer from 'torii/providers/oauth2-bearer';
-import { configurable } from 'torii/configuration';
+import Oauth2Bearer from '@adopted-ember-addons/torii/providers/oauth2-bearer';
+import { configurable } from '@adopted-ember-addons/torii/configuration';
 
 var GoogleOauth2Bearer = Oauth2Bearer.extend({
   name: 'google-oauth2-bearer',

--- a/addon/providers/google-oauth2.js
+++ b/addon/providers/google-oauth2.js
@@ -4,8 +4,8 @@
  * using the OAuth2 authorization flow in a popup window.
  */
 
-import Oauth2 from 'torii/providers/oauth2-code';
-import { configurable } from 'torii/configuration';
+import Oauth2 from '@adopted-ember-addons/torii/providers/oauth2-code';
+import { configurable } from '@adopted-ember-addons/torii/configuration';
 
 var GoogleOauth2 = Oauth2.extend({
   name: 'google-oauth2',

--- a/addon/providers/linked-in-oauth2.js
+++ b/addon/providers/linked-in-oauth2.js
@@ -1,6 +1,6 @@
 /* eslint-disable ember/avoid-leaking-state-in-ember-objects */
-import Oauth2 from 'torii/providers/oauth2-code';
-import { configurable } from 'torii/configuration';
+import Oauth2 from '@adopted-ember-addons/torii/providers/oauth2-code';
+import { configurable } from '@adopted-ember-addons/torii/configuration';
 
 /**
  * This class implements authentication against Linked In

--- a/addon/providers/oauth1.js
+++ b/addon/providers/oauth1.js
@@ -4,8 +4,8 @@
  * using the OAuth1.0a request token flow in a popup window.
  */
 
-import Provider from 'torii/providers/base';
-import { configurable } from 'torii/configuration';
+import Provider from '@adopted-ember-addons/torii/providers/base';
+import { configurable } from '@adopted-ember-addons/torii/configuration';
 
 var Oauth1 = Provider.extend({
   name: 'oauth1',

--- a/addon/providers/oauth2-bearer.js
+++ b/addon/providers/oauth2-bearer.js
@@ -1,5 +1,5 @@
 /* eslint-disable ember/no-get */
-import Provider from 'torii/providers/oauth2-code';
+import Provider from '@adopted-ember-addons/torii/providers/oauth2-code';
 
 var Oauth2Bearer = Provider.extend({
   responseType: 'token',

--- a/addon/providers/oauth2-code.js
+++ b/addon/providers/oauth2-code.js
@@ -1,10 +1,10 @@
 /* eslint-disable ember/avoid-leaking-state-in-ember-objects, ember/no-get, ember/no-side-effects */
 import { computed } from '@ember/object';
-import Provider from 'torii/providers/base';
-import { configurable } from 'torii/configuration';
-import QueryString from 'torii/lib/query-string';
-import requiredProperty from 'torii/lib/required-property';
-import randomUrlSafe from 'torii/lib/random-url-safe';
+import Provider from '@adopted-ember-addons/torii/providers/base';
+import { configurable } from '@adopted-ember-addons/torii/configuration';
+import QueryString from '@adopted-ember-addons/torii/lib/query-string';
+import requiredProperty from '@adopted-ember-addons/torii/lib/required-property';
+import randomUrlSafe from '@adopted-ember-addons/torii/lib/random-url-safe';
 
 function currentUrl() {
   var url = [

--- a/addon/providers/stripe-connect.js
+++ b/addon/providers/stripe-connect.js
@@ -1,6 +1,6 @@
 /* eslint-disable ember/avoid-leaking-state-in-ember-objects */
-import Oauth2 from 'torii/providers/oauth2-code';
-import { configurable } from 'torii/configuration';
+import Oauth2 from '@adopted-ember-addons/torii/providers/oauth2-code';
+import { configurable } from '@adopted-ember-addons/torii/configuration';
 
 export default Oauth2.extend({
   name: 'stripe-connect',

--- a/addon/providers/twitter-oauth1.js
+++ b/addon/providers/twitter-oauth1.js
@@ -1,4 +1,4 @@
-import Oauth1Provider from 'torii/providers/oauth1';
+import Oauth1Provider from '@adopted-ember-addons/torii/providers/oauth1';
 
 export default Oauth1Provider.extend({
   name: 'twitter',

--- a/addon/redirect-handler.js
+++ b/addon/redirect-handler.js
@@ -13,7 +13,7 @@ import EmberObject from '@ember/object';
 import EmberError from '@ember/error';
 
 import { CURRENT_REQUEST_KEY, WARNING_KEY } from './mixins/ui-service-mixin';
-import configuration from 'torii/configuration';
+import configuration from '@adopted-ember-addons/torii/configuration';
 
 export class ToriiRedirectError extends EmberError {
   constructor() {

--- a/addon/router-dsl-ext.js
+++ b/addon/router-dsl-ext.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import Router from '@ember/routing/router';
-import getRouterLib from 'torii/compat/get-router-lib';
+import getRouterLib from '@adopted-ember-addons/torii/compat/get-router-lib';
 
 var proto = Ember.RouterDSL.prototype;
 

--- a/addon/routing/application-route-mixin.js
+++ b/addon/routing/application-route-mixin.js
@@ -1,6 +1,6 @@
 /* eslint-disable ember/no-new-mixins */
 import Mixin from '@ember/object/mixin';
-import { getConfiguration } from 'torii/configuration';
+import { getConfiguration } from '@adopted-ember-addons/torii/configuration';
 import { getOwner } from '@ember/application';
 
 export default Mixin.create({

--- a/addon/routing/authenticated-route-mixin.js
+++ b/addon/routing/authenticated-route-mixin.js
@@ -3,7 +3,7 @@ import { resolve } from 'rsvp';
 import Mixin from '@ember/object/mixin';
 import { get } from '@ember/object';
 import { getOwner } from '@ember/application';
-import { getConfiguration } from 'torii/configuration';
+import { getConfiguration } from '@adopted-ember-addons/torii/configuration';
 
 export default Mixin.create({
   beforeModel(transition) {

--- a/addon/services/iframe.js
+++ b/addon/services/iframe.js
@@ -1,7 +1,7 @@
 /* eslint-disable ember/no-mixins, ember/no-classic-classes */
 import Evented from '@ember/object/evented';
 import EmberObject from '@ember/object';
-import UiServiceMixin from 'torii/mixins/ui-service-mixin';
+import UiServiceMixin from '@adopted-ember-addons/torii/mixins/ui-service-mixin';
 
 var Iframe = EmberObject.extend(Evented, UiServiceMixin, {
   openRemote(url) {

--- a/addon/services/popup.js
+++ b/addon/services/popup.js
@@ -1,7 +1,7 @@
 /* eslint-disable ember/no-mixins, no-prototype-builtins, ember/no-classic-classes */
 import Evented from '@ember/object/evented';
 import EmberObject from '@ember/object';
-import UiServiceMixin from 'torii/mixins/ui-service-mixin';
+import UiServiceMixin from '@adopted-ember-addons/torii/mixins/ui-service-mixin';
 
 function stringifyOptions(options) {
   var optionsStrings = [];

--- a/addon/services/torii-session.js
+++ b/addon/services/torii-session.js
@@ -4,8 +4,8 @@ import { Promise as EmberPromise, reject } from 'rsvp';
 import Service from '@ember/service';
 import { on } from '@ember/object/evented';
 import { computed } from '@ember/object';
-import createStateMachine from 'torii/session/state-machine';
-import { getOwner } from 'torii/lib/container-utils';
+import createStateMachine from '@adopted-ember-addons/torii/session/state-machine';
+import { getOwner } from '@adopted-ember-addons/torii/lib/container-utils';
 
 function lookupAdapter(container, authenticationType) {
   var adapter = container.lookup('torii-adapter:' + authenticationType);

--- a/addon/services/torii.js
+++ b/addon/services/torii.js
@@ -1,7 +1,7 @@
 /* eslint-disable ember/no-classic-classes */
 import Service from '@ember/service';
 import { Promise as EmberPromise } from 'rsvp';
-import { getOwner } from 'torii/lib/container-utils';
+import { getOwner } from '@adopted-ember-addons/torii/lib/container-utils';
 
 function lookupProvider(container, providerName) {
   return container.lookup('torii-provider:' + providerName);

--- a/addon/session/state-machine.js
+++ b/addon/session/state-machine.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-prototype-builtins */
-import StateMachine from 'torii/lib/state-machine';
+import StateMachine from '@adopted-ember-addons/torii/lib/state-machine';
 import { set } from '@ember/object';
 
 var transitionTo = StateMachine.transitionTo;

--- a/app/components/torii-iframe-placeholder.js
+++ b/app/components/torii-iframe-placeholder.js
@@ -1,3 +1,3 @@
-import toriiIframePlaceholder from 'torii/components/torii-iframe-placeholder';
+import toriiIframePlaceholder from '@adopted-ember-addons/torii/components/torii-iframe-placeholder';
 
 export default toriiIframePlaceholder;

--- a/app/initializers/initialize-torii-callback.js
+++ b/app/initializers/initialize-torii-callback.js
@@ -1,5 +1,5 @@
 import config from '../config/environment';
-import RedirectHandler from 'torii/redirect-handler';
+import RedirectHandler from '@adopted-ember-addons/torii/redirect-handler';
 
 export default {
   name: 'torii-callback',

--- a/app/initializers/initialize-torii-session.js
+++ b/app/initializers/initialize-torii-session.js
@@ -1,5 +1,5 @@
-import bootstrapSession from 'torii/bootstrap/session';
-import { getConfiguration } from 'torii/configuration';
+import bootstrapSession from '@adopted-ember-addons/torii/bootstrap/session';
+import { getConfiguration } from '@adopted-ember-addons/torii/configuration';
 
 export default {
   name: 'torii-session',

--- a/app/initializers/initialize-torii.js
+++ b/app/initializers/initialize-torii.js
@@ -1,5 +1,5 @@
-import bootstrapTorii from 'torii/bootstrap/torii';
-import { configure } from 'torii/configuration';
+import bootstrapTorii from '@adopted-ember-addons/torii/bootstrap/torii';
+import { configure } from '@adopted-ember-addons/torii/configuration';
 import config from '../config/environment';
 
 var initializer = {

--- a/app/instance-initializers/setup-routes.js
+++ b/app/instance-initializers/setup-routes.js
@@ -1,11 +1,11 @@
 /* eslint-disable ember/new-module-imports */
 
 import Ember from 'ember';
-import bootstrapRouting from 'torii/bootstrap/routing';
-import { getConfiguration } from 'torii/configuration';
-import getRouterInstance from 'torii/compat/get-router-instance';
-import getRouterLib from 'torii/compat/get-router-lib';
-import 'torii/router-dsl-ext';
+import bootstrapRouting from '@adopted-ember-addons/torii/bootstrap/routing';
+import { getConfiguration } from '@adopted-ember-addons/torii/configuration';
+import getRouterInstance from '@adopted-ember-addons/torii/compat/get-router-instance';
+import getRouterLib from '@adopted-ember-addons/torii/compat/get-router-lib';
+import '@adopted-ember-addons/torii/router-dsl-ext';
 
 export default {
   name: 'torii-setup-routes',

--- a/app/instance-initializers/walk-providers.js
+++ b/app/instance-initializers/walk-providers.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-prototype-builtins */
-import { lookup } from 'torii/lib/container-utils';
-import { getConfiguration } from 'torii/configuration';
+import { lookup } from '@adopted-ember-addons/torii/lib/container-utils';
+import { getConfiguration } from '@adopted-ember-addons/torii/configuration';
 
 export default {
   name: 'torii-walk-providers',

--- a/app/services/popup.js
+++ b/app/services/popup.js
@@ -1,1 +1,1 @@
-export { default } from 'torii/services/popup';
+export { default } from '@adopted-ember-addons/torii/services/popup';

--- a/app/services/torii-session.js
+++ b/app/services/torii-session.js
@@ -1,1 +1,1 @@
-export { default } from 'torii/services/torii-session';
+export { default } from '@adopted-ember-addons/torii/services/torii-session';

--- a/app/services/torii.js
+++ b/app/services/torii.js
@@ -1,1 +1,1 @@
-export { default } from 'torii/services/torii';
+export { default } from '@adopted-ember-addons/torii/services/torii';

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "torii",
+  "name": "@adopted-ember-addons/torii",
   "version": "1.0.0-beta.1",
   "description": "A set of clean abstractions for authentication in Ember.js",
   "keywords": [

--- a/tests/helpers/mock-popup-service.js
+++ b/tests/helpers/mock-popup-service.js
@@ -1,5 +1,5 @@
-import PopupService from 'torii/services/popup';
-import ParseQueryString from 'torii/lib/parse-query-string';
+import PopupService from '@adopted-ember-addons/torii/services/popup';
+import ParseQueryString from '@adopted-ember-addons/torii/lib/parse-query-string';
 import { resolve } from 'rsvp';
 
 export default class MyFirstPopup extends PopupService {

--- a/tests/integration/providers/azure-ad-oauth2-test.js
+++ b/tests/integration/providers/azure-ad-oauth2-test.js
@@ -1,6 +1,6 @@
 /* eslint-disable qunit/require-expect */
 import { setupTest } from 'ember-qunit';
-import { configure } from 'torii/configuration';
+import { configure } from '@adopted-ember-addons/torii/configuration';
 import { module, test } from 'qunit';
 
 import MockPopupService from '../../helpers/mock-popup-service';

--- a/tests/integration/providers/facebook-connect-test.js
+++ b/tests/integration/providers/facebook-connect-test.js
@@ -1,11 +1,11 @@
 /* eslint-disable qunit/require-expect, qunit/literal-compare-order */
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { configure } from 'torii/configuration';
+import { configure } from '@adopted-ember-addons/torii/configuration';
 import {
   overrideLoadScript,
   resetLoadScript,
-} from 'torii/providers/-private/utils';
+} from '@adopted-ember-addons/torii/providers/-private/utils';
 
 import buildFBMock from '../../helpers/build-fb-mock';
 

--- a/tests/integration/providers/facebook-oauth2-test.js
+++ b/tests/integration/providers/facebook-oauth2-test.js
@@ -1,6 +1,6 @@
 /* eslint-disable qunit/require-expect */
 import { setupTest } from 'ember-qunit';
-import { configure } from 'torii/configuration';
+import { configure } from '@adopted-ember-addons/torii/configuration';
 import { module, test } from 'qunit';
 
 import MockPopupService from '../../helpers/mock-popup-service';

--- a/tests/integration/providers/github-oauth2-test.js
+++ b/tests/integration/providers/github-oauth2-test.js
@@ -1,6 +1,6 @@
 /* eslint-disable qunit/require-expect */
 import { setupTest } from 'ember-qunit';
-import { configure } from 'torii/configuration';
+import { configure } from '@adopted-ember-addons/torii/configuration';
 import { module, test } from 'qunit';
 
 import MockPopupService from '../../helpers/mock-popup-service';

--- a/tests/integration/providers/google-oauth2-bearer-test.js
+++ b/tests/integration/providers/google-oauth2-bearer-test.js
@@ -1,5 +1,5 @@
 import { setupTest } from 'ember-qunit';
-import { configure } from 'torii/configuration';
+import { configure } from '@adopted-ember-addons/torii/configuration';
 import { module, test } from 'qunit';
 
 import MockPopupService from '../../helpers/mock-popup-service';

--- a/tests/integration/providers/google-oauth2-test.js
+++ b/tests/integration/providers/google-oauth2-test.js
@@ -1,6 +1,6 @@
 /* eslint-disable qunit/require-expect */
 import { setupTest } from 'ember-qunit';
-import { configure } from 'torii/configuration';
+import { configure } from '@adopted-ember-addons/torii/configuration';
 import { module, test } from 'qunit';
 
 import MockPopupService from '../../helpers/mock-popup-service';

--- a/tests/integration/providers/linked-in-oauth2-test.js
+++ b/tests/integration/providers/linked-in-oauth2-test.js
@@ -1,6 +1,6 @@
 /* eslint-disable qunit/require-expect */
 import { setupTest } from 'ember-qunit';
-import { configure } from 'torii/configuration';
+import { configure } from '@adopted-ember-addons/torii/configuration';
 import { module, test } from 'qunit';
 
 import MockPopupService from '../../helpers/mock-popup-service';

--- a/tests/integration/providers/oauth1-test.js
+++ b/tests/integration/providers/oauth1-test.js
@@ -1,9 +1,9 @@
 /* eslint-disable qunit/require-expect */
 import { setupTest } from 'ember-qunit';
-import { configure } from 'torii/configuration';
+import { configure } from '@adopted-ember-addons/torii/configuration';
 import { module, test } from 'qunit';
 
-import OAuth1Provider from 'torii/providers/oauth1';
+import OAuth1Provider from '@adopted-ember-addons/torii/providers/oauth1';
 import MockPopupService from '../../helpers/mock-popup-service';
 
 const requestTokenUri = 'http://localhost:3000/oauth/callback';

--- a/tests/integration/providers/stripe-connect-test.js
+++ b/tests/integration/providers/stripe-connect-test.js
@@ -1,6 +1,6 @@
 /* eslint-disable qunit/require-expect */
 import { setupTest } from 'ember-qunit';
-import { configure } from 'torii/configuration';
+import { configure } from '@adopted-ember-addons/torii/configuration';
 import { module, test } from 'qunit';
 import MockPopupService from '../../helpers/mock-popup-service';
 

--- a/tests/integration/session-test.js
+++ b/tests/integration/session-test.js
@@ -1,7 +1,7 @@
 /* eslint-disable qunit/no-negated-ok, qunit/require-expect */
 import { setupTest } from 'ember-qunit';
 
-import SessionService from 'torii/services/torii-session';
+import SessionService from '@adopted-ember-addons/torii/services/torii-session';
 import DummyAdapter from '../helpers/dummy-adapter';
 import DummySuccessProvider from '../helpers/dummy-success-provider';
 import DummyFailureProvider from '../helpers/dummy-failure-provider';

--- a/tests/unit/configuration-test.js
+++ b/tests/unit/configuration-test.js
@@ -1,7 +1,7 @@
 /* eslint-disable ember/no-classic-classes, ember/no-get */
 import EmberObject from '@ember/object';
 import { run } from '@ember/runloop';
-import { configurable, configure } from 'torii/configuration';
+import { configurable, configure } from '@adopted-ember-addons/torii/configuration';
 import { module, test } from 'qunit';
 
 module('Unit | Configuration', function (hooks) {

--- a/tests/unit/lib/parse-query-string-test.js
+++ b/tests/unit/lib/parse-query-string-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 
-import ParseQueryString from 'torii/lib/parse-query-string';
+import ParseQueryString from '@adopted-ember-addons/torii/lib/parse-query-string';
 
 module('Unit | Lib | ParseQueryString', function (/*hooks*/) {
   test('parses each passed key', function (assert) {

--- a/tests/unit/lib/popup-id-serializer-test.js
+++ b/tests/unit/lib/popup-id-serializer-test.js
@@ -1,5 +1,5 @@
 /* eslint-disable qunit/literal-compare-order */
-import PopupIdSerializer from 'torii/lib/popup-id-serializer';
+import PopupIdSerializer from '@adopted-ember-addons/torii/lib/popup-id-serializer';
 
 import { module, test } from 'qunit';
 

--- a/tests/unit/lib/query-string-test.js
+++ b/tests/unit/lib/query-string-test.js
@@ -1,6 +1,6 @@
 import { run } from '@ember/runloop';
 import EmberObject from '@ember/object';
-import QueryString from 'torii/lib/query-string';
+import QueryString from '@adopted-ember-addons/torii/lib/query-string';
 import { module, test } from 'qunit';
 
 let { freeze } = Object;

--- a/tests/unit/lib/state-machine-test.js
+++ b/tests/unit/lib/state-machine-test.js
@@ -1,5 +1,5 @@
 /* eslint-disable qunit/no-negated-ok */
-import StateMachine from 'torii/lib/state-machine';
+import StateMachine from '@adopted-ember-addons/torii/lib/state-machine';
 import { module, test } from 'qunit';
 
 module('Unit | Lib | State Machine', function (/*hooks*/) {

--- a/tests/unit/lib/uuid-generator-test.js
+++ b/tests/unit/lib/uuid-generator-test.js
@@ -1,4 +1,4 @@
-import UUIDGenerator from 'torii/lib/uuid-generator';
+import UUIDGenerator from '@adopted-ember-addons/torii/lib/uuid-generator';
 import { module, test } from 'qunit';
 
 module('Unit | Lib | UUIDGenerator', function (/*hooks*/) {

--- a/tests/unit/providers/azure-ad-oauth2-test.js
+++ b/tests/unit/providers/azure-ad-oauth2-test.js
@@ -1,7 +1,7 @@
 /* eslint-disable qunit/no-ok-equality */
 import { module, test } from 'qunit';
-import { configure } from 'torii/configuration';
-import AzureAdProvider from 'torii/providers/azure-ad-oauth2';
+import { configure } from '@adopted-ember-addons/torii/configuration';
+import AzureAdProvider from '@adopted-ember-addons/torii/providers/azure-ad-oauth2';
 
 module('Unit | Provider | AzureAdOAuth2Provider', function (hooks) {
   let provider;

--- a/tests/unit/providers/facebook-oauth2-test.js
+++ b/tests/unit/providers/facebook-oauth2-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
-import { configure } from 'torii/configuration';
+import { configure } from '@adopted-ember-addons/torii/configuration';
 
-import FacebookProvider from 'torii/providers/facebook-oauth2';
+import FacebookProvider from '@adopted-ember-addons/torii/providers/facebook-oauth2';
 
 module('Unit | Provider | FacebookOAuth2Provider', function (hooks) {
   let provider;

--- a/tests/unit/providers/google-oauth2-bearer-test.js
+++ b/tests/unit/providers/google-oauth2-bearer-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
-import { configure } from 'torii/configuration';
+import { configure } from '@adopted-ember-addons/torii/configuration';
 
-import GoogleBearerProvider from 'torii/providers/google-oauth2-bearer';
+import GoogleBearerProvider from '@adopted-ember-addons/torii/providers/google-oauth2-bearer';
 
 module('Unit | Provider | GoogleAuth2BearerProvider', function (hooks) {
   let provider;

--- a/tests/unit/providers/google-oauth2-test.js
+++ b/tests/unit/providers/google-oauth2-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
-import { configure } from 'torii/configuration';
+import { configure } from '@adopted-ember-addons/torii/configuration';
 
-import GoogleProvider from 'torii/providers/google-oauth2';
+import GoogleProvider from '@adopted-ember-addons/torii/providers/google-oauth2';
 
 module('Unit | Provider | GoogleAuth2Provider', function (hooks) {
   let provider;

--- a/tests/unit/providers/oauth1-test.js
+++ b/tests/unit/providers/oauth1-test.js
@@ -1,7 +1,7 @@
-import { configure } from 'torii/configuration';
+import { configure } from '@adopted-ember-addons/torii/configuration';
 import { module, test } from 'qunit';
 
-import BaseProvider from 'torii/providers/oauth1';
+import BaseProvider from '@adopted-ember-addons/torii/providers/oauth1';
 
 module(
   'Unit | Provider | MockOauth1Provider (oauth1 subclass)',

--- a/tests/unit/providers/oauth2-bearer-test.js
+++ b/tests/unit/providers/oauth2-bearer-test.js
@@ -1,8 +1,8 @@
 /* eslint-disable ember/avoid-leaking-state-in-ember-objects */
-import { configure } from 'torii/configuration';
+import { configure } from '@adopted-ember-addons/torii/configuration';
 import { module, test } from 'qunit';
 
-import BaseProvider from 'torii/providers/oauth2-bearer';
+import BaseProvider from '@adopted-ember-addons/torii/providers/oauth2-bearer';
 
 module(
   'Unit | Provider | MockOauth2Provider (oauth2-bearer subclass)',

--- a/tests/unit/providers/oauth2-code-test.js
+++ b/tests/unit/providers/oauth2-code-test.js
@@ -1,8 +1,8 @@
 /* eslint-disable ember/avoid-leaking-state-in-ember-objects, qunit/no-ok-equality */
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { configure } from 'torii/configuration';
-import BaseProvider from 'torii/providers/oauth2-code';
+import { configure } from '@adopted-ember-addons/torii/configuration';
+import BaseProvider from '@adopted-ember-addons/torii/providers/oauth2-code';
 
 module(
   'Unit | Provider | MockOauth2Provider (oauth2-code subclass)',

--- a/tests/unit/providers/stripe-connect-test.js
+++ b/tests/unit/providers/stripe-connect-test.js
@@ -1,6 +1,6 @@
 import { run } from '@ember/runloop';
-import { getConfiguration, configure } from 'torii/configuration';
-import StripeConnectProvider from 'torii/providers/stripe-connect';
+import { getConfiguration, configure } from '@adopted-ember-addons/torii/configuration';
+import StripeConnectProvider from '@adopted-ember-addons/torii/providers/stripe-connect';
 import QUnit from 'qunit';
 
 let { module, test } = QUnit;

--- a/tests/unit/redirect-handler-test.js
+++ b/tests/unit/redirect-handler-test.js
@@ -1,7 +1,7 @@
 /* eslint-disable ember/no-mixins, qunit/no-conditional-assertions, qunit/no-negated-ok, qunit/require-expect */
 import { run } from '@ember/runloop';
-import RedirectHandler from 'torii/redirect-handler';
-import { CURRENT_REQUEST_KEY } from 'torii/mixins/ui-service-mixin';
+import RedirectHandler from '@adopted-ember-addons/torii/redirect-handler';
+import { CURRENT_REQUEST_KEY } from '@adopted-ember-addons/torii/mixins/ui-service-mixin';
 import { module, test } from 'qunit';
 
 module('Unit | RedirectHandler', function (/*hooks*/) {

--- a/tests/unit/routing/application-route-mixin-test.js
+++ b/tests/unit/routing/application-route-mixin-test.js
@@ -2,9 +2,9 @@
 import { later } from '@ember/runloop';
 import { Promise as EmberPromise, reject } from 'rsvp';
 import Route from '@ember/routing/route';
-import ApplicationRouteMixin from 'torii/routing/application-route-mixin';
+import ApplicationRouteMixin from '@adopted-ember-addons/torii/routing/application-route-mixin';
 import { module, test } from 'qunit';
-import { configure, getConfiguration } from 'torii/configuration';
+import { configure, getConfiguration } from '@adopted-ember-addons/torii/configuration';
 import { setupTest } from 'ember-qunit';
 import { setOwner } from '@ember/application';
 import { inject as service } from '@ember/service';

--- a/tests/unit/routing/authenticated-route-mixin-test.js
+++ b/tests/unit/routing/authenticated-route-mixin-test.js
@@ -3,9 +3,9 @@ import EmberRouter from '@ember/routing/router';
 import { later } from '@ember/runloop';
 import { Promise as EmberPromise, resolve, reject } from 'rsvp';
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'torii/routing/authenticated-route-mixin';
+import AuthenticatedRouteMixin from '@adopted-ember-addons/torii/routing/authenticated-route-mixin';
 import { module, test } from 'qunit';
-import { configure, getConfiguration } from 'torii/configuration';
+import { configure, getConfiguration } from '@adopted-ember-addons/torii/configuration';
 import { setupTest } from 'ember-qunit';
 import { inject as service } from '@ember/service';
 

--- a/tests/unit/services/popup-test.js
+++ b/tests/unit/services/popup-test.js
@@ -1,8 +1,8 @@
 /* eslint-disable ember/no-mixins, qunit/resolve-async, qunit/literal-compare-order, qunit/require-expect, qunit/no-negated-ok */
 import { run } from '@ember/runloop';
-import Popup from 'torii/services/popup';
-import PopupIdSerializer from 'torii/lib/popup-id-serializer';
-import { CURRENT_REQUEST_KEY } from 'torii/mixins/ui-service-mixin';
+import Popup from '@adopted-ember-addons/torii/services/popup';
+import PopupIdSerializer from '@adopted-ember-addons/torii/lib/popup-id-serializer';
+import { CURRENT_REQUEST_KEY } from '@adopted-ember-addons/torii/mixins/ui-service-mixin';
 import { module, test } from 'qunit';
 
 module('Unit | Service | Popup', function (hooks) {

--- a/tests/unit/torii-test.js
+++ b/tests/unit/torii-test.js
@@ -1,4 +1,4 @@
-import Torii from 'torii/services/torii';
+import Torii from '@adopted-ember-addons/torii/services/torii';
 import { module, test } from 'qunit';
 
 module('Unit | Torii', function (/*hooks*/) {


### PR DESCRIPTION
Resurrects rename of `torii` to `@adopted-ember-addons/torii` from https://github.com/adopted-ember-addons/torii/pull/5 in light of https://github.com/adopted-ember-addons/torii/issues/7#issuecomment-1234490097