### PR TITLE
Add a dependency on `@ember/string`, require ember-auto-import@v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "release": "release-it"
   },
   "dependencies": {
+    "@ember/string": "^4.0.1",
+    "ember-auto-import": "^2.10.0",
     "ember-cli-babel": "^7.26.10",
     "ember-cli-htmlbars": "^5.7.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -964,12 +964,10 @@
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
 
-"@ember/string@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@ember/string/-/string-3.1.1.tgz#0a5ac0d1e4925259e41d5c8d55ef616117d47ff0"
-  integrity sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==
-  dependencies:
-    ember-cli-babel "^7.26.6"
+"@ember/string@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@ember/string/-/string-4.0.1.tgz#2c9d3f749bad92567e99ab5b8d4fdb5ed7f0ff0c"
+  integrity sha512-VWeng8BSWrIsdPfffOQt/bKwNKJL7+37gPFh/6iZZ9bke+S83kKqkS30poo4bTGfRcMnvAE0ie7txom+iDu81Q==
 
 "@ember/test-helpers@^2.6.0":
   version "2.9.4"
@@ -4616,7 +4614,7 @@ ember-auto-import@^1.11.3:
     walk-sync "^0.3.3"
     webpack "^4.43.0"
 
-ember-auto-import@^2.4.1, ember-auto-import@^2.4.3:
+ember-auto-import@^2.10.0, ember-auto-import@^2.4.1:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-2.10.0.tgz#2a29b82335eba4375d115570cbe836666ed2e7cc"
   integrity sha512-bcBFDYVTFHyqyq8BNvsj6UO3pE6Uqou/cNmee0WaqBgZ+1nQqFz0UE26usrtnFAT+YaFZSkqF2H36QW84k0/cg==


### PR DESCRIPTION
`@ember/string` is now a stand-alone package and doesn't ship with `ember-source`. https://deprecations.emberjs.com/v4.x/#toc_ember-string-add-package

This adds it as a declared dependency.

~(And updates the version of `node` specified in `.nvmrc` to something relatively modern.)~ The node update was made in https://github.com/adopted-ember-addons/torii/pull/43.